### PR TITLE
Allow LGPL license

### DIFF
--- a/.github/dependency-review-config.yaml
+++ b/.github/dependency-review-config.yaml
@@ -9,3 +9,4 @@ allow-licenses:
   - (MIT OR Apache-2.0) AND Unicode-DFS-2016
   - BSD-2-Clause AND BSD-3-Clause
   - Python-2.0.1
+  - LGPL-3.0


### PR DESCRIPTION
> The license allows developers and companies to use and integrate a software component released under the LGPL into their own (even [proprietary](https://en.wikipedia.org/wiki/Proprietary_software)) software without being required by the terms of a strong [copyleft](https://en.wikipedia.org/wiki/Copyleft) license to release the source code of their own components.
> \- https://en.wikipedia.org/wiki/GNU_Lesser_General_Public_License