### PR TITLE
Add CAL-1.0 to allowed licenses

### DIFF
--- a/.github/dependency-review-config.yaml
+++ b/.github/dependency-review-config.yaml
@@ -10,3 +10,4 @@ allow-licenses:
   - BSD-2-Clause AND BSD-3-Clause
   - Python-2.0.1
   - LGPL-3.0
+  - CAL-1.0


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow
